### PR TITLE
add support for custom bad profiles file

### DIFF
--- a/codetta_align.py
+++ b/codetta_align.py
@@ -14,6 +14,7 @@ def argument_parsing():
     parser.add_argument('-p', '--profiles', help='profile HMM database file, must be in located in resource directory (default: Pfam-A_enone.hmm)')
     parser.add_argument('--parallelize_hmmscan', help='send hmmscan jobs to computing cluster. Specify SLURM (s), and modify template file in resources directory accordingly.', type=str, choices=['s'])
     parser.add_argument('--resource_directory', help='directory where resource files can be found (default: [script dir]/resources)', type=str)
+    parser.add_argument('--bad_profiles', help='list of profiles that should be excluded from the analysis', type=str)
         
     return parser.parse_args()
 
@@ -42,7 +43,7 @@ def main():
     args.selenocysteine_pfams = None
     args.pyrrolysine_pfams = None
     initialize_globals()
-    initialize_emissions_dict(args.resource_directory, args.profiles)
+    initialize_emissions_dict(args.resource_directory, args.profiles, args.bad_profiles)
     gc = GeneticCode(args)
     
     gc.processing_genome()

--- a/codetta_infer.py
+++ b/codetta_infer.py
@@ -21,6 +21,7 @@ def argument_parsing():
     parser.add_argument('-u', '--selenocysteine_pfams', help='flag to include Pfam domains known to contain selenocysteine', action="store_true", default=False)
     parser.add_argument('-y', '--pyrrolysine_pfams', help='flag to include Pfam domains known to contain pyrrolysine', action="store_true", default=False)
     parser.add_argument('--resource_directory', help='directory where resource files can be found (default: [script dir]/resources)', type=str)
+    parser.add_argument('--bad_profiles', help='list of profiles that should be excluded from the analysis', type=str)
         
     return parser.parse_args()
 
@@ -42,7 +43,7 @@ def main():
     
     # initialize genetic code with command line args and download genome
     initialize_globals()
-    initialize_emissions_dict(args.resource_directory, args.profiles)
+    initialize_emissions_dict(args.resource_directory, args.profiles, args.bad_profiles)
     gc = GeneticCode(args)
     
     # infer genetic code

--- a/codetta_summary.py
+++ b/codetta_summary.py
@@ -13,6 +13,7 @@ def argument_parsing():
     parser.add_argument('-p', '--profiles', help='profile HMM database file, must be in located in resource directory (default: Pfam-A_enone.hmm)')
     parser.add_argument('-e', '--evalue', help='profile HMM hit e-value threshold (default: 1e-10)', type=float, default=1e-10)
     parser.add_argument('--resource_directory', help='directory where resource files can be found (default: [script dir]/resources)', type=str)
+    parser.add_argument('--bad_profiles', help='list of profiles that should be excluded from the analysis', type=str)
         
     return parser.parse_args()
 
@@ -42,7 +43,7 @@ def main():
     args.selenocysteine_pfams = None
     args.pyrrolysine_pfams = None
     initialize_globals()
-    initialize_emissions_dict(args.resource_directory, args.profiles)
+    initialize_emissions_dict(args.resource_directory, args.profiles, args.bad_profiles)
     gc = GeneticCode(args)
     
     gc.process_hmmscan_results()


### PR DESCRIPTION
Added a new command-line argument, `--bad_profiles file_name`, which allows the specification of a file containing a custom set of profiles that should be excluded from the analysis (one profile name per line).